### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ This is supposed to go into the `shake-build` directory of the GHC source tree.
 Trying it
 ---------
 
+Prerequisits
+```
+$ cabal install alex
+$ cabal install shake
+```
+
 On Linux,
 ```
 $ git clone git://git.haskell.org/ghc


### PR DESCRIPTION
Adding missing prerequisites. These are probably installed if you build ghc often or use shake, but if not, these are missing.