### PR TITLE
Add Cabal sandboxed build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .shake/
 .db/
 cfg/system.config
+cabal.sandbox.config
+dist/
+.cabal-sandbox/

--- a/README.md
+++ b/README.md
@@ -1,32 +1,44 @@
 Shaking up GHC
 ==============
 
-As part of my 6-month research secondment to Microsoft Research in Cambridge I am taking up the challenge of migrating the current [GHC](https://en.wikipedia.org/wiki/Glasgow_Haskell_Compiler) build system based on standard `make` into a new and (hopefully) better one based on [Shake](https://github.com/ndmitchell/shake/blob/master/README.md). If you are curious about the project you can find more details on the [wiki page](https://ghc.haskell.org/trac/ghc/wiki/Building/Shake) and in this [blog post](https://blogs.ncl.ac.uk/andreymokhov/shaking-up-ghc/).
+As part of my 6-month research secondment to Microsoft Research in Cambridge
+I am taking up the challenge of migrating the current [GHC][ghc] build system
+based on standard `make` into a new and (hopefully) better one based on
+[Shake][shake]. If you are curious about the project you can find more details
+on the [wiki page][ghc-shake-wiki] and in this [blog post][shake-blog-post].
 
 This is supposed to go into the `shake-build` directory of the GHC source tree.
+
+
+
+
 
 Trying it
 ---------
 
-Prerequisits
-```
-$ cabal install alex
-$ cabal install shake
+### Linux
+
+```bash
+git clone git://git.haskell.org/ghc
+cd ghc
+git submodule update --init
+git clone git://github.com/snowleopard/shaking-up-ghc shake-build
+./boot
+./configure
+make inplace/bin/ghc-cabal   # This needs to be fixed
 ```
 
-On Linux,
-```
-$ git clone git://git.haskell.org/ghc
-$ cd ghc
-$ git submodule update --init
-$ git clone git://github.com/snowleopard/shaking-up-ghc shake-build
-$ ./boot
-$ ./configure
-$ make inplace/bin/ghc-cabal   # This needs to be fixed
-$ shake-build/build.sh
-```
+Now you have a couple of options:
 
-On Windows,
+- `./shake-build/build.sh` to run the script directly. You'll need to have
+  `shake` installed globally.
+- `./shake-build/build.cabal.sh` to install the build system in a Cabal sandbox
+  and then run it.
+
+
+
+### Windows
+
 ```
 $ git clone --recursive git://git.haskell.org/ghc.git
 $ cd ghc
@@ -36,8 +48,28 @@ $ ./configure --enable-tarballs-autodownload
 $ make inplace/bin/ghc-cabal   # This needs to be fixed
 $ shake-build/build.bat
 ```
-Also see the Building GHC on Windows guide: https://ghc.haskell.org/trac/ghc/wiki/Building/Preparation/Windows.
+Also see the [Building GHC on Windows guide][ghc-windows-building-guide].
+
+
+
+
 
 How to contribute
 -----------------
-The best way to contribute is to try the new build system, report the issues you found, and attempt to fix them. Please note the codebase is very unstable at present and we expect a lot of further refactoring. Before attempting to fix any issue do make sure no one else is already working on it. The documentation is currently non-existent, but we will start addressing this once the codebase stabilises.
+
+The best way to contribute is to try the new build system, report the issues
+you found, and attempt to fix them. Please note the codebase is very unstable
+at present and we expect a lot of further refactoring. Before attempting to
+fix any issue do make sure no one else is already working on it. The
+documentation is currently non-existent, but we will start addressing this
+once the codebase stabilises.
+
+
+
+
+
+[ghc-shake-wiki]: https://ghc.haskell.org/trac/ghc/wiki/Building/Shake
+[ghc-windows-building-guide]: https://ghc.haskell.org/trac/ghc/wiki/Building/Preparation/Windows
+[ghc]: https://en.wikipedia.org/wiki/Glasgow_Haskell_Compiler
+[shake-blog-post]: https://blogs.ncl.ac.uk/andreymokhov/shaking-up-ghc
+[shake]: https://github.com/ndmitchell/shake/blob/master/README.md

--- a/build.cabal.sh
+++ b/build.cabal.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+absoltueRoot="$(dirname "$(readlink -f "$0")")"
+cd "$absoltueRoot"
+
+# Initialize sandbox if necessary
+if ! $(cabal sandbox hc-pkg list 2>&1 > /dev/null); then
+    cabal sandbox init
+    cabal install                   \
+        --disable-library-profiling \
+        --disable-shared
+fi
+
+cabal run ghc-shake --             \
+    --lint                         \
+    --directory "$absoltueRoot/.." \
+    --colour                       \
+    "$@"

--- a/shaking-up-ghc.cabal
+++ b/shaking-up-ghc.cabal
@@ -1,0 +1,91 @@
+name:                shaking-up-ghc
+version:             0.1.0.0
+synopsis:            GHC build system
+license:             BSD3
+license-file:        LICENSE
+author:              Andrey Mokhov, Github: @snowleopard
+maintainer:          Andrey Mokhov, Github: @snowleopard
+copyright:           Andrey Mokhov, Github: @snowleopard
+category:            Development
+build-type:          Simple
+cabal-version:       >=1.10
+
+source-repository head
+    type:     git
+    location: https://github.com/snowleopard/shaking-up-ghc
+
+executable ghc-shake
+    main-is:             Main.hs
+    hs-source-dirs:      src
+    other-modules:       Base
+                       , Builder
+                       , Expression
+                       , GHC
+                       , Oracles
+                       , Oracles.ArgsHash
+                       , Oracles.Config
+                       , Oracles.Config.Flag
+                       , Oracles.Config.Setting
+                       , Oracles.Dependencies
+                       , Oracles.ModuleFiles
+                       , Oracles.PackageData
+                       , Oracles.PackageDeps
+                       , Oracles.WindowsRoot
+                       , Package
+                       , Predicates
+                       , Rules
+                       , Rules.Actions
+                       , Rules.Cabal
+                       , Rules.Compile
+                       , Rules.Config
+                       , Rules.Data
+                       , Rules.Dependencies
+                       , Rules.Documentation
+                       , Rules.Generate
+                       , Rules.Library
+                       , Rules.Oracles
+                       , Rules.Package
+                       , Rules.Program
+                       , Rules.Resources
+                       , Settings
+                       , Settings.Args
+                       , Settings.Builders.Alex
+                       , Settings.Builders.Ar
+                       , Settings.Builders.Gcc
+                       , Settings.Builders.GenPrimopCode
+                       , Settings.Builders.Ghc
+                       , Settings.Builders.GhcCabal
+                       , Settings.Builders.GhcPkg
+                       , Settings.Builders.Haddock
+                       , Settings.Builders.Happy
+                       , Settings.Builders.Hsc2Hs
+                       , Settings.Builders.HsCpp
+                       , Settings.Builders.Ld
+                       , Settings.Packages
+                       , Settings.TargetDirectory
+                       , Settings.User
+                       , Settings.Ways
+                       , Stage
+                       , Target
+                       , Way
+
+    default-extensions:  BangPatterns
+                       , LambdaCase
+                       , MultiWayIf
+                       , OverloadedStrings
+                       , TupleSections
+    other-extensions:    DeriveDataTypeable
+                       , DeriveGeneric
+                       , FlexibleInstances
+    build-depends:       base
+                       , ansi-terminal >= 0.6
+                       , Cabal >= 1.22
+                       , containers >= 0.5
+                       , directory >= 1.2
+                       , extra >= 1.4
+                       , mtl >= 2.2
+                       , shake >= 0.15
+                       , transformers >= 0.4
+                       , unordered-containers >= 0.2
+    default-language:    Haskell2010
+    ghc-options:         -Wall -rtsopts -with-rtsopts=-I0 -j


### PR DESCRIPTION
Add a Cabal and sandbox based way to execute the build system.

Due to problems with Stack bringing its own libraries, I wasn't able to use it to successfully run the GHC build system yet.