### PR TITLE
Begin paring down reexports

### DIFF
--- a/src/Base.hs
+++ b/src/Base.hs
@@ -12,7 +12,6 @@ module Base (
     module Development.Shake,
     module Development.Shake.Classes,
     module Development.Shake.FilePath,
-    module Development.Shake.Util,
 
     -- * Paths
     shakeFilesPath, configPath, sourcePath, programInplacePath,
@@ -38,7 +37,6 @@ import Data.Monoid
 import Development.Shake hiding (unit, (*>), parallel)
 import Development.Shake.Classes
 import Development.Shake.FilePath
-import Development.Shake.Util
 import System.Console.ANSI
 import qualified System.Directory as IO
 import System.IO

--- a/src/Base.hs
+++ b/src/Base.hs
@@ -39,7 +39,7 @@ import Data.Function
 import Data.List
 import Data.Maybe
 import Data.Monoid
-import Development.Shake hiding (unit, (*>))
+import Development.Shake hiding (unit, (*>), parallel)
 import Development.Shake.Classes
 import Development.Shake.Config
 import Development.Shake.FilePath

--- a/src/Base.hs
+++ b/src/Base.hs
@@ -22,7 +22,6 @@ module Base (
 
     -- * Output
     putColoured, putOracle, putBuild, putSuccess, putError, renderBox,
-    module System.Console.ANSI,
 
     -- * Miscellaneous utilities
     bimap, minusOrd, intersectOrd, replaceEq, quote, chunksOfSize,

--- a/src/Base.hs
+++ b/src/Base.hs
@@ -11,7 +11,6 @@ module Base (
     -- * Shake
     module Development.Shake,
     module Development.Shake.Classes,
-    module Development.Shake.Config,
     module Development.Shake.FilePath,
     module Development.Shake.Util,
 
@@ -38,7 +37,6 @@ import Data.Maybe
 import Data.Monoid
 import Development.Shake hiding (unit, (*>), parallel)
 import Development.Shake.Classes
-import Development.Shake.Config
 import Development.Shake.FilePath
 import Development.Shake.Util
 import System.Console.ANSI

--- a/src/Base.hs
+++ b/src/Base.hs
@@ -2,11 +2,11 @@ module Base (
     -- * General utilities
     module Control.Applicative,
     module Control.Monad.Extra,
-    module Control.Monad.Reader,
     module Data.Function,
     module Data.List,
     module Data.Maybe,
     module Data.Monoid,
+    MonadTrans(lift),
 
     -- * Shake
     module Development.Shake,

--- a/src/Base.hs
+++ b/src/Base.hs
@@ -3,7 +3,6 @@ module Base (
     module Control.Applicative,
     module Control.Monad.Extra,
     module Control.Monad.Reader,
-    module Data.Char,
     module Data.Function,
     module Data.List,
     module Data.Maybe,
@@ -34,7 +33,6 @@ module Base (
 import Control.Applicative
 import Control.Monad.Extra
 import Control.Monad.Reader
-import Data.Char
 import Data.Function
 import Data.List
 import Data.Maybe

--- a/src/Builder.hs
+++ b/src/Builder.hs
@@ -3,6 +3,8 @@ module Builder (
     Builder (..), builderPath, getBuilderPath, specified, needBuilder
     ) where
 
+import Control.Monad.Trans.Reader
+
 import Base
 import GHC.Generics (Generic)
 import Oracles

--- a/src/Builder.hs
+++ b/src/Builder.hs
@@ -10,12 +10,12 @@ import GHC.Generics (Generic)
 import Oracles
 import Stage
 
--- A Builder is an external command invoked in separate process using Shake.cmd
+-- | A 'Builder' is an external command invoked in separate process using 'Shake.cmd'
 --
--- Ghc Stage0 is the bootstrapping compiler
--- Ghc StageN, N > 0, is the one built on stage (N - 1)
--- GhcPkg Stage0 is the bootstrapping GhcPkg
--- GhcPkg StageN, N > 0, is the one built in Stage0 (TODO: need only Stage1?)
+-- @Ghc Stage0@ is the bootstrapping compiler
+-- @Ghc StageN@, N > 0, is the one built on stage (N - 1)
+-- @GhcPkg Stage0@ is the bootstrapping @GhcPkg@
+-- @GhcPkg StageN@, N > 0, is the one built in Stage0 (TODO: need only Stage1?)
 -- TODO: Do we really need HsCpp builder? Can't we use a generic Cpp
 --       builder instead? It would also be used instead of GccM.
 -- TODO: rename Gcc to CCompiler? We sometimes use gcc and sometimes clang.
@@ -73,7 +73,8 @@ builderKey builder = case builder of
     Objdump          -> "objdump"
     Unlit            -> "unlit"
 
--- TODO: Paths to some builders should be determined using defaultProgramPath
+-- | Determine the location of a 'Builder'
+-- TODO: Paths to some builders should be determined using 'defaultProgramPath'
 builderPath :: Builder -> Action FilePath
 builderPath builder = do
     path <- askConfigWithDefault (builderKey builder) $
@@ -87,8 +88,8 @@ getBuilderPath = lift . builderPath
 specified :: Builder -> Action Bool
 specified = fmap (not . null) . builderPath
 
--- Make sure a builder exists on the given path and rebuild it if out of date.
--- If laxDependencies is True then we do not rebuild GHC even if it is out of
+-- | Make sure a builder exists on the given path and rebuild it if out of date.
+-- If 'laxDependencies' is True then we do not rebuild GHC even if it is out of
 -- date (can save a lot of build time when changing GHC).
 needBuilder :: Bool -> Builder -> Action ()
 needBuilder laxDependencies builder = do

--- a/src/Expression.hs
+++ b/src/Expression.hs
@@ -24,6 +24,8 @@ module Expression (
     module Way
     ) where
 
+import Control.Monad.Trans.Reader
+
 import Base
 import Package
 import Builder

--- a/src/Expression.hs
+++ b/src/Expression.hs
@@ -18,7 +18,6 @@ module Expression (
     getInput, getOutput,
 
     -- * Re-exports
-    module Base,
     module Builder,
     module Package,
     module Stage,

--- a/src/Oracles/ArgsHash.hs
+++ b/src/Oracles/ArgsHash.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DeriveDataTypeable, GeneralizedNewtypeDeriving #-}
 module Oracles.ArgsHash (checkArgsHash, argsHashOracle) where
 
+import Base
 import Expression
 import Settings
 import Settings.Args

--- a/src/Oracles/Config.hs
+++ b/src/Oracles/Config.hs
@@ -3,6 +3,7 @@ module Oracles.Config (askConfig, askConfigWithDefault, configOracle) where
 
 import Base
 import qualified Data.HashMap.Strict as Map
+import Development.Shake.Config
 
 newtype ConfigKey = ConfigKey String
     deriving (Show, Typeable, Eq, Hashable, Binary, NFData)

--- a/src/Oracles/Config/Flag.hs
+++ b/src/Oracles/Config/Flag.hs
@@ -4,6 +4,8 @@ module Oracles.Config.Flag (
     ghcWithNativeCodeGen, supportsSplitObjects
     ) where
 
+import Control.Monad.Trans.Reader
+
 import Base
 import Oracles.Config
 import Oracles.Config.Setting

--- a/src/Oracles/Config/Setting.hs
+++ b/src/Oracles/Config/Setting.hs
@@ -6,6 +6,8 @@ module Oracles.Config.Setting (
     ghcCanonVersion, cmdLineLengthLimit
     ) where
 
+import Control.Monad.Trans.Reader
+
 import Base
 import Oracles.Config
 import Stage

--- a/src/Oracles/PackageData.hs
+++ b/src/Oracles/PackageData.hs
@@ -4,6 +4,7 @@ module Oracles.PackageData (
     pkgData, pkgDataList, packageDataOracle
     ) where
 
+import Development.Shake.Config
 import Base
 import qualified Data.HashMap.Strict as Map
 

--- a/src/Oracles/WindowsRoot.hs
+++ b/src/Oracles/WindowsRoot.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DeriveDataTypeable, GeneralizedNewtypeDeriving #-}
 module Oracles.WindowsRoot (windowsRoot, windowsRootOracle) where
 
+import Data.Char (isSpace)
 import Base
 
 newtype WindowsRoot = WindowsRoot ()

--- a/src/Predicates.hs
+++ b/src/Predicates.hs
@@ -6,6 +6,7 @@ module Predicates (
     stage0, stage1, stage2, notStage0, notPackage, registerPackage, splitObjects
     ) where
 
+import Base
 import Expression
 import GHC
 import Oracles.Config.Flag

--- a/src/Predicates.hs
+++ b/src/Predicates.hs
@@ -1,7 +1,5 @@
+-- | Convenient predicates
 module Predicates (
-    module GHC,
-    module Oracles.Config.Flag,
-    module Oracles.Config.Setting,
     stage, package, builder, stagedBuilder, file, way,
     stage0, stage1, stage2, notStage0, notPackage, registerPackage, splitObjects
     ) where
@@ -10,7 +8,6 @@ import Base
 import Expression
 import GHC
 import Oracles.Config.Flag
-import Oracles.Config.Setting
 
 -- Basic predicates
 stage :: Stage -> Predicate

--- a/src/Rules.hs
+++ b/src/Rules.hs
@@ -1,5 +1,6 @@
 module Rules (generateTargets, packageRules) where
 
+import Base
 import Expression
 import Rules.Install
 import Rules.Package

--- a/src/Rules/Actions.hs
+++ b/src/Rules/Actions.hs
@@ -1,5 +1,6 @@
 module Rules.Actions (build, buildWithResources) where
 
+import Base
 import Expression
 import Oracles.ArgsHash
 import Settings

--- a/src/Rules/Cabal.hs
+++ b/src/Rules/Cabal.hs
@@ -1,5 +1,6 @@
 module Rules.Cabal (cabalRules) where
 
+import Base
 import Data.Version
 import Distribution.Package as DP
 import Distribution.PackageDescription

--- a/src/Rules/Compile.hs
+++ b/src/Rules/Compile.hs
@@ -1,5 +1,6 @@
 module Rules.Compile (compilePackage) where
 
+import Base
 import Expression
 import Oracles
 import Rules.Actions

--- a/src/Rules/Data.hs
+++ b/src/Rules/Data.hs
@@ -1,5 +1,6 @@
 module Rules.Data (buildPackageData) where
 
+import Base
 import Expression
 import GHC
 import Oracles

--- a/src/Rules/Dependencies.hs
+++ b/src/Rules/Dependencies.hs
@@ -1,5 +1,6 @@
 module Rules.Dependencies (buildPackageDependencies) where
 
+import Base
 import Expression
 import Oracles
 import Rules.Actions

--- a/src/Rules/Dependencies.hs
+++ b/src/Rules/Dependencies.hs
@@ -7,6 +7,7 @@ import Rules.Actions
 import Rules.Generate
 import Rules.Resources
 import Settings
+import Development.Shake.Util (parseMakefile)
 
 buildPackageDependencies :: Resources -> PartialTarget -> Rules ()
 buildPackageDependencies _ target @ (PartialTarget stage pkg) =

--- a/src/Rules/Documentation.hs
+++ b/src/Rules/Documentation.hs
@@ -1,5 +1,6 @@
 module Rules.Documentation (buildPackageDocumentation) where
 
+import Base
 import Expression
 import Oracles
 import Rules.Actions

--- a/src/Rules/Generate.hs
+++ b/src/Rules/Generate.hs
@@ -3,6 +3,7 @@ module Rules.Generate (
     derivedConstantsPath, generatedDependencies
     ) where
 
+import Base
 import Expression
 import GHC
 import Rules.Generators.ConfigHs

--- a/src/Rules/Generators/ConfigHs.hs
+++ b/src/Rules/Generators/ConfigHs.hs
@@ -1,5 +1,6 @@
 module Rules.Generators.ConfigHs (generateConfigHs) where
 
+import Base
 import Expression
 import GHC
 import Oracles

--- a/src/Rules/Generators/GhcAutoconfH.hs
+++ b/src/Rules/Generators/GhcAutoconfH.hs
@@ -1,5 +1,6 @@
 module Rules.Generators.GhcAutoconfH (generateGhcAutoconfH) where
 
+import Base
 import Expression
 import Oracles
 

--- a/src/Rules/Generators/GhcBootPlatformH.hs
+++ b/src/Rules/Generators/GhcBootPlatformH.hs
@@ -1,5 +1,6 @@
 module Rules.Generators.GhcBootPlatformH (generateGhcBootPlatformH) where
 
+import Base
 import Expression
 import Oracles
 

--- a/src/Rules/Generators/GhcPlatformH.hs
+++ b/src/Rules/Generators/GhcPlatformH.hs
@@ -1,5 +1,6 @@
 module Rules.Generators.GhcPlatformH (generateGhcPlatformH) where
 
+import Base
 import Expression
 import Oracles
 

--- a/src/Rules/Generators/VersionHs.hs
+++ b/src/Rules/Generators/VersionHs.hs
@@ -1,5 +1,6 @@
 module Rules.Generators.VersionHs (generateVersionHs) where
 
+import Base
 import Expression
 import Oracles
 

--- a/src/Rules/Install.hs
+++ b/src/Rules/Install.hs
@@ -1,5 +1,6 @@
 module Rules.Install (installTargets, installRules) where
 
+import Base
 import Expression
 import GHC
 import Rules.Generate

--- a/src/Rules/Library.hs
+++ b/src/Rules/Library.hs
@@ -2,6 +2,7 @@ module Rules.Library (buildPackageLibrary, cSources, hSources) where
 
 import Data.Char
 
+import Base
 import Expression hiding (splitPath)
 import GHC
 import Oracles

--- a/src/Rules/Library.hs
+++ b/src/Rules/Library.hs
@@ -2,8 +2,8 @@ module Rules.Library (buildPackageLibrary, cSources, hSources) where
 
 import Data.Char
 
-import Base
-import Expression hiding (splitPath)
+import Base hiding (splitPath)
+import Expression
 import GHC
 import Oracles
 import Predicates (splitObjects)

--- a/src/Rules/Library.hs
+++ b/src/Rules/Library.hs
@@ -1,5 +1,7 @@
 module Rules.Library (buildPackageLibrary, cSources, hSources) where
 
+import Data.Char
+
 import Expression hiding (splitPath)
 import GHC
 import Oracles

--- a/src/Rules/Program.hs
+++ b/src/Rules/Program.hs
@@ -1,5 +1,7 @@
 module Rules.Program (buildProgram) where
 
+import Data.Char
+
 import Expression hiding (splitPath)
 import GHC hiding (ghci)
 import Oracles

--- a/src/Rules/Program.hs
+++ b/src/Rules/Program.hs
@@ -2,6 +2,7 @@ module Rules.Program (buildProgram) where
 
 import Data.Char
 
+import Base
 import Expression hiding (splitPath)
 import GHC hiding (ghci)
 import Oracles

--- a/src/Settings.hs
+++ b/src/Settings.hs
@@ -7,6 +7,7 @@ module Settings (
     getPackagePath, getTargetDirectory, getTargetPath, getPackageSources
     ) where
 
+import Base
 import Expression
 import Oracles
 import Oracles.ModuleFiles
@@ -16,13 +17,13 @@ import Settings.User
 import Settings.Ways
 
 getPackagePath :: Expr FilePath
-getPackagePath = liftM pkgPath getPackage
+getPackagePath = pkgPath <$> getPackage
 
 getTargetDirectory :: Expr FilePath
-getTargetDirectory = liftM2 targetDirectory getStage getPackage
+getTargetDirectory = targetDirectory <$> getStage <*> getPackage
 
 getTargetPath :: Expr FilePath
-getTargetPath = liftM2 targetPath getStage getPackage
+getTargetPath = targetPath <$> getStage <*> getPackage
 
 getPkgData :: (FilePath -> PackageData) -> Expr String
 getPkgData key = lift . pkgData . key =<< getTargetPath

--- a/src/Settings/Args.hs
+++ b/src/Settings/Args.hs
@@ -1,5 +1,7 @@
 module Settings.Args (getArgs) where
 
+import Data.Monoid
+
 import Expression
 import Settings.Builders.Alex
 import Settings.Builders.Ar

--- a/src/Settings/Builders/Ar.hs
+++ b/src/Settings/Builders/Ar.hs
@@ -1,5 +1,6 @@
 module Settings.Builders.Ar (arArgs, arCmd) where
 
+import Base
 import Expression
 import Oracles
 import Predicates (builder)

--- a/src/Settings/Builders/DeriveConstants.hs
+++ b/src/Settings/Builders/DeriveConstants.hs
@@ -2,6 +2,7 @@ module Settings.Builders.DeriveConstants (
     derivedConstantsPath, deriveConstantsArgs
     ) where
 
+import Base
 import Expression
 import Oracles.Config.Flag
 import Oracles.Config.Setting

--- a/src/Settings/Builders/Gcc.hs
+++ b/src/Settings/Builders/Gcc.hs
@@ -1,8 +1,10 @@
 module Settings.Builders.Gcc (gccArgs, gccMArgs) where
 
+import Development.Shake.FilePath
 import Expression
 import GHC
 import Oracles
+import Base ((-/-))
 import Predicates (package, stagedBuilder)
 import Settings
 

--- a/src/Settings/Builders/Ghc.hs
+++ b/src/Settings/Builders/Ghc.hs
@@ -1,5 +1,6 @@
 module Settings.Builders.Ghc (ghcArgs, ghcMArgs, commonGhcArgs) where
 
+import Base
 import Expression
 import Oracles
 import GHC

--- a/src/Settings/Builders/GhcCabal.hs
+++ b/src/Settings/Builders/GhcCabal.hs
@@ -3,13 +3,7 @@ module Settings.Builders.GhcCabal (
     customPackageArgs, ccArgs, cppArgs, ccWarnings, argStagedSettingList, needDll0
     ) where
 
-import Data.Monoid
-import Control.Monad.Trans.Class
-import Control.Monad.Extra
-
-import Development.Shake
-import Development.Shake.FilePath
-import Base ((-/-), bootPackageConstraints)
+import Base
 import Oracles.Config.Setting
 import Oracles.Config.Flag
 import GHC

--- a/src/Settings/Builders/GhcCabal.hs
+++ b/src/Settings/Builders/GhcCabal.hs
@@ -3,6 +3,20 @@ module Settings.Builders.GhcCabal (
     customPackageArgs, ccArgs, cppArgs, ccWarnings, argStagedSettingList, needDll0
     ) where
 
+import Data.Monoid
+import Control.Monad.Trans.Class
+import Control.Monad.Extra
+
+import Development.Shake
+import Development.Shake.FilePath
+import Base ((-/-), bootPackageConstraints)
+import Oracles.Config.Setting
+import Oracles.Config.Flag
+import GHC
+import Package
+import Way
+import Builder
+import Stage
 import Expression
 import Predicates hiding (stage)
 import Settings

--- a/src/Settings/Builders/GhcPkg.hs
+++ b/src/Settings/Builders/GhcPkg.hs
@@ -1,5 +1,7 @@
 module Settings.Builders.GhcPkg (ghcPkgArgs) where
 
+import Base
+import Builder
 import Expression
 import Predicates
 import Settings

--- a/src/Settings/Builders/Haddock.hs
+++ b/src/Settings/Builders/Haddock.hs
@@ -2,6 +2,7 @@ module Settings.Builders.Haddock (haddockArgs) where
 
 import Development.Shake.FilePath
 import Base
+import GHC
 import Package
 import Expression
 import Oracles

--- a/src/Settings/Builders/Haddock.hs
+++ b/src/Settings/Builders/Haddock.hs
@@ -1,5 +1,8 @@
 module Settings.Builders.Haddock (haddockArgs) where
 
+import Development.Shake.FilePath
+import Base
+import Package
 import Expression
 import Oracles
 import Predicates hiding (file)

--- a/src/Settings/Builders/Hsc2Hs.hs
+++ b/src/Settings/Builders/Hsc2Hs.hs
@@ -1,5 +1,9 @@
 module Settings.Builders.Hsc2Hs (hsc2HsArgs) where
 
+import Control.Monad.Trans.Class
+import Control.Monad.Extra
+
+import Base
 import Expression
 import Oracles
 import Predicates (builder, stage0, notStage0)

--- a/src/Settings/Packages.hs
+++ b/src/Settings/Packages.hs
@@ -1,5 +1,6 @@
 module Settings.Packages (getPackages, knownPackages, findKnownPackage) where
 
+import Base
 import Expression
 import Predicates
 import Settings.User

--- a/src/Settings/Packages.hs
+++ b/src/Settings/Packages.hs
@@ -2,7 +2,9 @@ module Settings.Packages (getPackages, knownPackages, findKnownPackage) where
 
 import Base
 import Expression
+import GHC
 import Predicates
+import Oracles.Config.Setting
 import Settings.User
 
 -- Combining default list of packages with user modifications

--- a/src/Settings/TargetDirectory.hs
+++ b/src/Settings/TargetDirectory.hs
@@ -3,6 +3,7 @@ module Settings.TargetDirectory (
     pkgGhciLibraryFile
     ) where
 
+import Base
 import Expression
 import Settings.User
 

--- a/src/Settings/User.hs
+++ b/src/Settings/User.hs
@@ -6,8 +6,8 @@ module Settings.User (
     verboseCommands, turnWarningsIntoErrors
     ) where
 
+import GHC
 import Expression
-import Predicates
 
 -- No user-specific settings by default
 -- TODO: rename to userArgs

--- a/src/Settings/Ways.hs
+++ b/src/Settings/Ways.hs
@@ -4,6 +4,7 @@ import Data.Monoid
 import Expression
 import Predicates
 import Settings.User
+import Oracles.Config.Flag
 
 -- TODO: use a single expression Ways parameterised by package instead of
 -- expressions libWays and rtsWays

--- a/src/Settings/Ways.hs
+++ b/src/Settings/Ways.hs
@@ -1,5 +1,6 @@
 module Settings.Ways (getWays, getLibWays, getRtsWays) where
 
+import Data.Monoid
 import Expression
 import Predicates
 import Settings.User

--- a/src/Target.hs
+++ b/src/Target.hs
@@ -3,6 +3,8 @@ module Target (
     Target (..), PartialTarget (..), fromPartial, fullTarget, fullTargetWithWay
     ) where
 
+import Control.Monad.Trans.Reader
+
 import Base
 import Builder
 import GHC.Generics (Generic)


### PR DESCRIPTION
This is the beginning of what appears to be a rather large undertaking. I began by eliminating some of the easier reexports. I expect we'll want to retain something like `Base`, which will act as a sort of project-local `Prelude` but otherwise re-exports will be limited to the sort of tree-like structures described in #33.