### PR TITLE
Adds ghcautoconf and ghcplatform as dependencies to hp2ps.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,6 @@ git submodule update --init
 git clone git://github.com/snowleopard/shaking-up-ghc shake-build
 ./boot
 ./configure --with-gcc=$(which clang) # See #26
-./shake-build/build.sh includes/ghcautoconf.h # See #48
-./shake-build/build.sh includes/ghcplatform.h # See #48
-cp utils/hsc2hs/template-hsc.h inplace/lib/template-hsc.h # See #44
 ./shake-build/build.sh
 ```
 

--- a/src/Rules/Dependencies.hs
+++ b/src/Rules/Dependencies.hs
@@ -19,12 +19,14 @@ buildPackageDependencies _ target @ (PartialTarget stage pkg) =
         (buildPath <//> "*.c.deps") %> \out -> do
             let srcFile = dropBuild . dropExtension $ out
             when (pkg == compiler) . need $ platformH : includesDependencies
+            when (pkg == hp2ps) . need $ ["includes/ghcautoconf.h", "includes/ghcplatform.h"]
             need [srcFile]
             build $ fullTarget target (GccM stage) [srcFile] [out]
 
         hDepFile %> \out -> do
             srcs <- interpretPartial target getPackageSources
             when (pkg == compiler) . need $ platformH : includesDependencies
+            when (pkg == hp2ps) . need $ ["includes/ghcautoconf.h", "includes/ghcplatform.h"]
             -- TODO: very ugly and fragile; use gcc -MM instead?
             let extraDeps = if pkg /= compiler then [] else fmap (buildPath -/-)
                    [ "primop-vector-uniques.hs-incl"


### PR DESCRIPTION
 1fcb025 added includes to the dependencies for the `compiler` package, but `hp2ps` already requires them and is built prior to the `compiler` package. This should fix #48 for good.

Also updates the README.md to reflect the closure of #44.