### PR TITLE
Fixes the -B path for the ghcWrapper.

### DIFF
--- a/src/Rules/Wrappers/Ghc.hs
+++ b/src/Rules/Wrappers/Ghc.hs
@@ -11,4 +11,4 @@ ghcWrapper program = do
     return $ unlines
         [ "#!/bin/bash"
         , "exec " ++ (top -/- program)
-          ++ " -B" ++ (top -/- takeDirectory program) ++ " ${1+\"$@\"}" ]
+          ++ " -B" ++ (top -/- "inplace" -/- "lib") ++ " ${1+\"$@\"}" ]


### PR DESCRIPTION
the -B option expects "inplace/lib", where takeDirectroy yields: "inplace/lib/bin"