### PR TITLE
Travis CI using dirty tricks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,32 @@
+sudo: false
+
+matrix:
+  include:
+    - env: CABALVER=1.22 GHCVER=7.10.3
+      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3,zlib1g-dev,terminfo-dev],  sources: [hvr-ghc]}}
+
+before_install:
+
+    - PATH="$HOME/.cabal/bin:$PATH"
+    - PATH="/opt/ghc/$GHCVER/bin:$PATH"
+    - PATH="/opt/cabal/$CABALVER/bin:$PATH"
+    - export PATH
+
+    - .travis/print-env.sh
+
+install:
+    - .travis/install-cabal-happy-alex.sh
+    - .travis/install-ghc.sh
+    - .travis/install-ghc-shake.sh
+
+script:
+    - .travis/run-ghc-shake.sh
+
+cache:
+    directories:
+        - $HOME/.cabal
+        # - ghc/shake-build/.cabal-sandbox
+        # - ghc/shake-build/cabal.sandbox.config
+
+# before_cache:
+#     - rm -rf ghc/shake-build

--- a/.travis/install-cabal-happy-alex.sh
+++ b/.travis/install-cabal-happy-alex.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+COLOR="\e[32m" # Green
+RESET="\e[m"
+
+echo -e "${COLOR}GHC version:${RESET}"
+ghc --version
+
+echo -e "${COLOR}Cabal version:${RESET}"
+cabal --version
+
+echo -e "${COLOR}Update Cabal${RESET}"
+cabal update
+
+echo -e "${COLOR}Install Alex+Happy${RESET}"
+cabal install alex happy

--- a/.travis/install-ghc-shake.sh
+++ b/.travis/install-ghc-shake.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+COLOR="\e[31m" # Red, because this file is serious business
+RESET="\e[m"
+
+echo -e "${COLOR}Brutally hacking GHC-Shake to its proper location${RESET}"
+SHAKEDIR="ghc/shake-build"
+mkdir -p "$SHAKEDIR"
+mv .git "$SHAKEDIR/"
+( cd "$SHAKEDIR" && git reset --hard HEAD )
+
+echo -e "${COLOR}Installing deps into sandbox${RESET}"
+( cd "$SHAKEDIR" && cabal sandbox init )
+( cd "$SHAKEDIR" && cabal install --only-dependencies . )

--- a/.travis/install-ghc.sh
+++ b/.travis/install-ghc.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+COLOR="\e[34m" # Blue
+RESET="\e[m"
+
+echo -e "${COLOR}Clone GHC source${RESET}"
+git clone git://git.haskell.org/ghc
+
+echo -e "${COLOR}Initialize GHC submodules${RESET}"
+( cd ghc && git submodule update --init )
+
+echo -e "${COLOR}GHC boot/configure${RESET}"
+( cd ghc && ./boot && ./configure)

--- a/.travis/print-env.sh
+++ b/.travis/print-env.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+COLOR="\e[32m" # Green
+RESET="\e[m"
+
+echo -e "${COLOR}Environment:${RESET}"
+env

--- a/.travis/run-ghc-shake.sh
+++ b/.travis/run-ghc-shake.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+COLOR="\e[32m" # Green
+RESET="\e[m"
+
+echo -e "${COLOR}Running Shake build system${RESET}"
+( cd ghc && ./shake-build/build.cabal.sh )

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Shaking up GHC
 ==============
 
+[![Build Status](https://travis-ci.org/snowleopard/shaking-up-ghc.svg)](https://travis-ci.org/snowleopard/shaking-up-ghc)
+
 As part of my 6-month research secondment to Microsoft Research in Cambridge
 I am taking up the challenge of migrating the current [GHC][ghc] build system
 based on standard `make` into a new and (hopefully) better one based on


### PR DESCRIPTION
A rather hacky way to get CI going.

The problem is that Travis clones into a certain directory, but we'd like the Shake build system to be part of a second clone we have to do explicitly (GHC). The script does some dirty tricks to get it done™, but we should probably clean up the attempt a bit in the future.

CI build log: https://travis-ci.org/quchen/shaking-up-ghc