### PR TITLE
Adds derivedConstantsDependencies for rts

### DIFF
--- a/src/Rules/Generate.hs
+++ b/src/Rules/Generate.hs
@@ -69,10 +69,15 @@ compilerDependencies stage =
        , "primop-vector-tycons.hs-incl"
        , "primop-vector-tys.hs-incl" ]
 
+integerGmpDependencies :: [FilePath]
+integerGmpDependencies = ((pkgPath integerGmp -/- "gmp") -/-) <$>
+    [ "gmp.h" ] -- identical to integerGmpLibraryH, but doesn't require the import.
+
 generatedDependencies :: Stage -> Package -> [FilePath]
 generatedDependencies stage pkg
     | pkg == compiler = compilerDependencies stage
     | pkg == rts = derivedConstantsDependencies
+    | pkg == integerGmp = integerGmpDependencies
     | stage == Stage0 = defaultDependencies
     | otherwise = []
 

--- a/src/Rules/Generate.hs
+++ b/src/Rules/Generate.hs
@@ -72,6 +72,7 @@ compilerDependencies stage =
 generatedDependencies :: Stage -> Package -> [FilePath]
 generatedDependencies stage pkg
     | pkg == compiler = compilerDependencies stage
+    | pkg == rts = derivedConstantsDependencies
     | stage == Stage0 = defaultDependencies
     | otherwise = []
 

--- a/src/Settings/Packages/Rts.hs
+++ b/src/Settings/Packages/Rts.hs
@@ -49,6 +49,13 @@ rtsPackageArgs = package rts ? do
           [ arg "-Irts"
           , arg $ "-I" ++ path -/- "build"
           , arg $ "-DRtsWay=\"rts_" ++ show way ++ "\""
+          -- rts **must** be compiled with optimizations. The INLINE_HEADER macro,
+          -- requires that functions are inlined to work as expected.  Inlining
+          -- only happens for optimized builds. Otherwise we can assume that
+          -- there is a non-inlined variant to use instead. But rts does not
+          -- provide non-inlined alternatives and hence needs the function to
+          -- be inlined. See also Issue #90
+          , arg $ "-O2"
 
           , (file "//RtsMessages.*" ||^ file "//Trace.*") ?
             arg ("-DProjectVersion=" ++ quote projectVersion)


### PR DESCRIPTION
Building rts depends on derived constants, as we can not rely on the compiler to be build prior to rts,
as we build rts with gcc, and hence do not depend on ghc, we need to have rts depend on the derived
constants. This fixes #94. However, if we are going to build rts with the stage1 ghc, this should not be
an issue anymore (see #90), as derived constants would be build then anyway. Yet I do not see any
problem with explicilty noting down the derived constants dependency for rts.