### PR TITLE
Adds -no-hs-main to iservBin

### DIFF
--- a/shaking-up-ghc.cabal
+++ b/shaking-up-ghc.cabal
@@ -87,6 +87,7 @@ executable ghc-shake
                        , Settings.Packages.Haddock
                        , Settings.Packages.Hp2ps
                        , Settings.Packages.IntegerGmp
+                       , Settings.Packages.IservBin
                        , Settings.Packages.Rts
                        , Settings.Packages.RunGhc
                        , Settings.TargetDirectory

--- a/src/Settings/Args.hs
+++ b/src/Settings/Args.hs
@@ -27,6 +27,7 @@ import Settings.Packages.GhcPrim
 import Settings.Packages.Haddock
 import Settings.Packages.Hp2ps
 import Settings.Packages.IntegerGmp
+import Settings.Packages.IservBin
 import Settings.Packages.Rts
 import Settings.Packages.RunGhc
 import Settings.User
@@ -72,5 +73,6 @@ defaultPackageArgs = mconcat
     , haddockPackageArgs
     , hp2psPackageArgs
     , integerGmpPackageArgs
+    , iservBinPackageArgs
     , rtsPackageArgs
     , runGhcPackageArgs ]

--- a/src/Settings/Packages/IservBin.hs
+++ b/src/Settings/Packages/IservBin.hs
@@ -1,0 +1,10 @@
+module Settings.Packages.IservBin (iservBinPackageArgs) where
+
+import Expression
+import GHC (iservBin)
+import Predicates (builderGhc, package)
+
+iservBinPackageArgs :: Args
+iservBinPackageArgs = package iservBin ? do
+    mconcat [ builderGhc ?
+              mconcat [ arg "-no-hs-main" ]]


### PR DESCRIPTION
Fixes #102. But does not *yet* include the generation of the wrapper script.