### PR TITLE
[WIP] Use Cabal for package data

### DIFF
--- a/src/Builder.hs
+++ b/src/Builder.hs
@@ -7,7 +7,9 @@ import Control.Monad.Trans.Reader
 
 import Base
 import GHC.Generics (Generic)
-import Oracles
+import Oracles.Config
+import Oracles.Config.Setting
+import Oracles.WindowsRoot
 import Stage
 
 -- | A 'Builder' is an external command invoked in separate process using 'Shake.cmd'

--- a/src/Oracles/GhcCabalData.hs
+++ b/src/Oracles/GhcCabalData.hs
@@ -1,0 +1,92 @@
+{-# LANGUAGE DeriveDataTypeable, GeneralizedNewtypeDeriving, GADTs #-}
+
+module Oracles.PackageData (
+    PackageData (..), PackageDataList (..),
+    pkgData, pkgDataList, packageDataOracle
+    ) where
+
+import Development.Shake.Config
+import Base
+import qualified Data.HashMap.Strict as Map
+
+-- For each (PackageData path) the file 'path/package-data.mk' contains
+-- a line of the form 'path_VERSION = 1.2.3.4'.
+-- pkgData $ PackageData path is an action that consults the file and
+-- returns "1.2.3.4".
+--
+-- PackageDataList is used for multiple string options separated by spaces,
+-- such as 'path_MODULES = Data.Array Data.Array.Base ...'.
+-- pkgListData Modules therefore returns ["Data.Array", "Data.Array.Base", ...]
+data PackageDataField a where
+    Package          :: PackageDataKey PackageIdentifier
+    BuildGhciLib     :: PackageDataKey Bool
+    CcArgs           :: PackageDataKey [String]
+    CSources         :: PackageDataKey [FilePath]
+    CppArgs          :: PackageDataKey [String]
+    DepCcArgs        :: PackageDataKey [String]
+    DepExtraLibs     :: PackageDataKey [FilePath]
+    Dependencies     :: PackageDataKey [PackageIdentifier]
+    DepIncludeDirs   :: PackageDataKey [FilePath]
+    DepLdArgs        :: PackageDataKey [String]
+    DepLibDirs       :: PackageDataKey [String]
+    HiddenModules    :: PackageDataKey [ModuleName]
+    HsArgs           :: PackageDataKey [String]
+    IncludeDirs      :: PackageDataKey [FilePath]
+    LdArgs           :: PackageDataKey [String]
+    Modules          :: PackageDataKey [ModuleName]
+    SrcDirs          :: PackageDataKey [FilePath]
+    TransitiveDeps   :: PackageDataKey [PackageIdentifier]
+
+newtype PackageDataKey = PackageDataKey (FilePath, String)
+    deriving (Show, Typeable, Eq, Hashable, Binary, NFData)
+
+askPackageData :: FilePath -> String -> Action String
+askPackageData path key = do
+    let fullKey = replaceSeparators '_' $ path ++ "_" ++ key
+        file    = path -/- "package-data.mk"
+    maybeValue <- askOracle $ PackageDataKey (file, fullKey)
+    case maybeValue of
+        Nothing    -> return ""
+        Just value -> return value
+        -- Nothing    -> putError $ "No key '" ++ key ++ "' in " ++ file ++ "."
+
+pkgData :: PackageData -> Action String
+pkgData packageData = case packageData of
+    BuildGhciLib path -> askPackageData path "BUILD_GHCI_LIB"
+    ComponentId  path -> askPackageData path "COMPONENT_ID"
+    Synopsis     path -> askPackageData path "SYNOPSIS"
+    Version      path -> askPackageData path "VERSION"
+
+pkgDataList :: PackageDataList -> Action [String]
+pkgDataList packageData = fmap (map unquote . words) $ case packageData of
+    CcArgs             path -> askPackageData path "CC_OPTS"
+    CSrcs              path -> askPackageData path "C_SRCS"
+    CppArgs            path -> askPackageData path "CPP_OPTS"
+    DepCcArgs          path -> askPackageData path "DEP_CC_OPTS"
+    DepExtraLibs       path -> askPackageData path "DEP_EXTRA_LIBS"
+    DepIds             path -> askPackageData path "DEP_IPIDS"
+    DepIncludeDirs     path -> askPackageData path "DEP_INCLUDE_DIRS_SINGLE_QUOTED"
+    DepLibDirs         path -> askPackageData path "DEP_LIB_DIRS_SINGLE_QUOTED"
+    DepLdArgs          path -> askPackageData path "DEP_LD_OPTS"
+    DepNames           path -> askPackageData path "DEP_NAMES"
+    Deps               path -> askPackageData path "DEPS"
+    HiddenModules      path -> askPackageData path "HIDDEN_MODULES"
+    HsArgs             path -> askPackageData path "HC_OPTS"
+    IncludeDirs        path -> askPackageData path "INCLUDE_DIRS"
+    LdArgs             path -> askPackageData path "LD_OPTS"
+    Modules            path -> askPackageData path "MODULES"
+    SrcDirs            path -> askPackageData path "HS_SRC_DIRS"
+    TransitiveDepNames path -> askPackageData path "TRANSITIVE_DEP_NAMES"
+  where
+    unquote = dropWhile (== '\'') . dropWhileEnd (== '\'')
+
+-- Oracle for 'package-data.mk' files
+packageDataOracle :: Rules ()
+packageDataOracle = do
+    pkgDataContents <- newCache $ \file -> do
+        need [file]
+        putOracle $ "Reading " ++ file ++ "..."
+        liftIO $ readConfigFile file
+    _ <- addOracle $ \(PackageDataKey (file, key)) ->
+        Map.lookup key <$> pkgDataContents file
+    return ()

--- a/src/Oracles/PackageData/Internals.hs
+++ b/src/Oracles/PackageData/Internals.hs
@@ -1,0 +1,106 @@
+module Oracles.PackageData.Internals where
+
+import Base
+import Package
+import Stage
+import GHC hiding (compiler)
+import Settings.TargetDirectory
+
+import Distribution.ModuleName as ModuleName
+import Distribution.Package
+import Distribution.PackageDescription as PD
+import Distribution.PackageDescription.Parse
+import Distribution.Simple (defaultHookedPackageDesc)
+import Distribution.Simple.LocalBuildInfo as LBI
+import Distribution.Simple.Program
+import Distribution.Simple.Compiler
+import Distribution.Simple.Configure (getPersistBuildConfig)
+import Distribution.Verbosity
+import qualified Distribution.InstalledPackageInfo as Installed
+import qualified Distribution.Simple.PackageIndex as PackageIndex
+
+-- | Various information of interest scaped from Cabal's 'BuildInfo'.
+data PackageData = PackageData { pdPackage        :: PackageIdentifier
+                               , pdDependencies   :: [PackageIdentifier]
+                               , pdTransitiveDeps :: [PackageIdentifier]
+                               , pdDepCcArgs      :: [String]
+                               , pdDepLdArgs      :: [String]
+                               , pdDepExtraLibs   :: [String]
+                               , pdDepIncludeDirs :: [FilePath]
+                               , pdDepLibDirs     :: [FilePath]
+
+                               , pdHcArgs         :: [String]
+                               , pdCcArgs         :: [String]
+                               , pdCppArgs        :: [String]
+                               , pdLdArgs         :: [String]
+                               , pdIncludeDirs    :: [FilePath]
+                               , pdIncludes       :: [String]
+                               , pdCSources       :: [FilePath]
+                               , pdModules        :: [ModuleName]
+                               , pdHiddenModules  :: [ModuleName]
+                               , pdWithGHCiLib    :: Bool
+                               }
+
+getPackageData :: Stage -> Package.Package -> Action PackageData
+getPackageData stage pkg
+    | pkg == hp2ps = error "TODO"
+    | otherwise    = do
+        -- Largely stolen from utils/ghc-cabal/Main.hs
+        let verbosity = silent
+        let distdir = targetPath stage pkg
+        need [pkgCabalFile pkg]
+        lbi <- liftIO $ getPersistBuildConfig distdir
+        let pd0 = localPkgDescr lbi
+        hooked_bi <-
+            if (buildType pd0 == Just Configure) || (buildType pd0 == Just Custom)
+            then do
+                maybe_infoFile <- liftIO defaultHookedPackageDesc
+                case maybe_infoFile of
+                    Nothing       -> return emptyHookedBuildInfo
+                    Just infoFile -> liftIO $ readHookedBuildInfo verbosity infoFile
+            else
+                return emptyHookedBuildInfo
+
+        let pd = updatePackageDescription hooked_bi pd0
+
+        let libBiModules lib = (libBuildInfo lib, libModules lib)
+            exeBiModules exe = (buildInfo exe, ModuleName.main : exeModules exe)
+            biModuless = (maybeToList $ fmap libBiModules $ PD.library pd)
+                      ++ (map exeBiModules $ executables pd)
+            buildableBiModuless = filter isBuildable biModuless
+                where isBuildable (bi', _) = buildable bi'
+            (bi, modules) = case buildableBiModuless of
+                            [] -> error "No buildable component found"
+                            [biModules] -> biModules
+                            _ -> error ("XXX ghc-cabal can't handle " ++
+                                        "more than one buildinfo yet")
+        let forDeps f = concatMap f dep_pkgs
+            dep_pkgs = PackageIndex.topologicalOrder (installedPkgs lbi)
+            transitive_dep_ids = map Installed.sourcePackageId dep_pkgs
+
+        let Just ghcProg = lookupProgram ghcProgram (withPrograms lbi)
+            hc_args = programDefaultArgs ghcProg
+                   ++ hcOptions GHC bi
+                   ++ languageToFlags (compiler lbi) (defaultLanguage bi)
+                   ++ extensionsToFlags (compiler lbi) (usedExtensions bi)
+                   ++ programOverrideArgs ghcProg
+
+        pure PackageData { pdPackage         = packageId pd
+                         , pdDependencies    = map snd $ externalPackageDeps lbi
+                         , pdTransitiveDeps  = transitive_dep_ids
+                         , pdDepCcArgs       = forDeps Installed.ccOptions
+                         , pdDepLdArgs       = forDeps Installed.ldOptions
+                         , pdDepLibDirs      = forDeps Installed.libraryDirs
+                         , pdDepIncludeDirs  = forDeps Installed.includeDirs
+                         , pdDepExtraLibs    = forDeps Installed.extraLibraries
+                         , pdHcArgs          = hc_args
+                         , pdCcArgs          = ccOptions bi
+                         , pdCppArgs         = cppOptions bi
+                         , pdLdArgs          = ldOptions bi
+                         , pdIncludeDirs     = includeDirs bi
+                         , pdIncludes        = includes bi
+                         , pdCSources        = cSources bi
+                         , pdModules         = modules
+                         , pdHiddenModules   = otherModules bi
+                         , pdWithGHCiLib     = withGHCiLib lbi
+                         }

--- a/src/Oracles/PackageDeps.hs
+++ b/src/Oracles/PackageDeps.hs
@@ -1,30 +1,19 @@
 {-# LANGUAGE DeriveDataTypeable, GeneralizedNewtypeDeriving #-}
-module Oracles.PackageDeps (packageDeps, packageDepsOracle) where
+module Oracles.PackageDeps  where
 
 import Base
 import qualified Data.HashMap.Strict as Map
 import Package
-import Settings.TargetDirectory
 
-import Distribution.ModuleName
-import Distribution.PackageDescription
-import Distribution.PackageDescription.Configuration
-import Distribution.Simple (defaultHookedPackageDesc)
-import Distribution.Simple.LocalBuildInfo
-import Distribution.Simple.Configure (getPersistBuildConfig)
-import Distribution.Verbosity
-import qualified Distribution.InstalledPackageInfo as Installed
-import qualified Distribution.Simple.PackageIndex as PackageIndex
-
-newtype PackageDepsKey = PackageDepsKey PackageName
+newtype PackageDepsKey = PackageDepsKey Package.PackageName
     deriving (Show, Typeable, Eq, Hashable, Binary, NFData)
 
 -- packageDeps name is an action that given a package looks up its dependencies
 -- in Base.packageDependencies file. The dependencies need to be computed by
 -- scanning package cabal files (see Rules.Cabal).
-packageDeps :: Package -> Action [PackageName]
+packageDeps :: Package.Package -> Action [Package.PackageName]
 packageDeps pkg = do
-    res <- askOracle . PackageDepsKey . pkgName $ pkg
+    res <- askOracle . PackageDepsKey . Package.pkgName $ pkg
     return . fromMaybe [] $ res
 
 -- Oracle for the package dependencies file
@@ -34,32 +23,7 @@ packageDepsOracle = do
         putOracle $ "Reading package dependencies..."
         contents <- readFileLines packageDependencies
         return . Map.fromList
-               $ [ (head ps, tail ps) | line <- contents, let ps = map PackageName $ words line ]
+               $ [ (head ps, tail ps) | line <- contents, let ps = map Package.PackageName $ words line ]
     _ <- addOracle $ \(PackageDepsKey pkg) -> Map.lookup pkg <$> deps ()
     return ()
 
-
-packageDependencies :: Stage -> Package -> Action [PackageName]
-pacakgeDependencies stage pkg
-    | pkg == hp2ps = return []
-    | otherwise    = do
-        let distdir = targetPath stage pkg
-        need [pkgCabalFile pkg]
-        lbi <- getPersistBuildConfig distdir
-        hooked_bi <-
-            if (buildType pd0 == Just Configure) || (buildType pd0 == Just Custom)
-            then do
-                maybe_infoFile <- defaultHookedPackageDesc
-                case maybe_infoFile of
-                    Nothing       -> return emptyHookedBuildInfo
-                    Just infoFile -> readHookedBuildInfo verbosity infoFile
-            else
-                return emptyHookedBuildInfo
-
-        let pd = updatePackageDescription hooked_bi pd0
-        let transitive_dep_ids = map Installed.sourcePackageId dep_pkgs
-            dep_ipids = map (display . Installed.installedComponentId) dep_direct
-            dep_pkgs = PackageIndex.topologicalOrder (packageHacks (installedPkgs lbi))
-
-        pd <- liftIO $ readPackageDescription silent $ pkgCabalFile pkg
-        buildDepends pd

--- a/src/Way.hs
+++ b/src/Way.hs
@@ -15,7 +15,7 @@ module Way (
 import Base hiding (unit)
 import Data.IntSet (IntSet)
 import qualified Data.IntSet as Set
-import Oracles
+import Oracles.Config.Setting
 
 -- Note: order of constructors is important for compatibility with the old build
 -- system, e.g. we want "thr_p", not "p_thr" (see instance Show Way).


### PR DESCRIPTION
This is a work-in-progress branch to fix #18 that I've had sitting around for lack of time. I believe much of the Cabal logic looks pretty good and it ought to produce everything that we need.

What it lacks is a good way to expose the various pieces of `PackageData` with an oracle such that we maintain minimal rebuilds.

I'm putting this here to provide a starting-point for someone wanting to take up this project before I am able to continue it myself.