### PR TITLE
Removes -Wall and -fwarn-tabs

### DIFF
--- a/src/Settings/Builders/Ghc.hs
+++ b/src/Settings/Builders/Ghc.hs
@@ -24,8 +24,8 @@ ghcBuilderArgs = stagedBuilder Ghc ? do
             , arg "-H32m"
             , stage0    ? arg "-O"
             , notStage0 ? arg "-O2"
-            , arg "-Wall"
-            , arg "-fwarn-tabs"
+            , warnAll ? arg "-Wall"
+            , warnTabs ? arg "-fwarn-tabs"
             , splitObjects ? arg "-split-objs"
             , not buildObj ? arg "-no-auto-link-packages"
             , not buildObj ? append [ "-optl-l" ++ lib | lib <- libs    ]

--- a/src/Settings/Builders/Ghc.hs
+++ b/src/Settings/Builders/Ghc.hs
@@ -24,8 +24,8 @@ ghcBuilderArgs = stagedBuilder Ghc ? do
             , arg "-H32m"
             , stage0    ? arg "-O"
             , notStage0 ? arg "-O2"
-            , warnAll ? arg "-Wall"
-            , warnTabs ? arg "-fwarn-tabs"
+            , arg "-Wall"
+            , arg "-fwarn-tabs"
             , splitObjects ? arg "-split-objs"
             , not buildObj ? arg "-no-auto-link-packages"
             , not buildObj ? append [ "-optl-l" ++ lib | lib <- libs    ]

--- a/src/Settings/User.hs
+++ b/src/Settings/User.hs
@@ -3,7 +3,7 @@ module Settings.User (
     userProgramPath, userKnownPackages, integerLibrary,
     trackBuildSystem, buildHaddock, validating, ghciWithDebugger, ghcProfiled,
     ghcDebugged, dynamicGhcPrograms, laxDependencies, buildSystemConfigFile,
-    verboseCommands, turnWarningsIntoErrors, splitObjects
+    verboseCommands, warnAll, warnTabs, turnWarningsIntoErrors, splitObjects
     ) where
 
 import GHC
@@ -60,6 +60,14 @@ validating = False
 -- To switch off split objects change to 'return False'
 splitObjects :: Predicate
 splitObjects = return False -- FIXME: should be defaultSplitObjects, see #84.
+
+-- | switch @-Wall@ on during ghc compilation passes.
+warnAll :: Predicate
+warnAll = return False
+
+-- | switch @-fwarn-tabs@ on during ghc compiliation passes.
+warnTabs :: Predicate
+warnTabs = return False
 
 dynamicGhcPrograms :: Bool
 dynamicGhcPrograms = False

--- a/src/Settings/User.hs
+++ b/src/Settings/User.hs
@@ -3,16 +3,17 @@ module Settings.User (
     userProgramPath, userKnownPackages, integerLibrary,
     trackBuildSystem, buildHaddock, validating, ghciWithDebugger, ghcProfiled,
     ghcDebugged, dynamicGhcPrograms, laxDependencies, buildSystemConfigFile,
-    verboseCommands, warnAll, warnTabs, turnWarningsIntoErrors, splitObjects
+    verboseCommands, turnWarningsIntoErrors, splitObjects
     ) where
 
 import GHC
 import Expression
+import Predicates (builderGhc)
 
 -- No user-specific settings by default
 -- TODO: rename to userArgs
 userArgs :: Args
-userArgs = mempty
+userArgs = builderGhc ? remove ["-Wall", "-fwarn-tabs"]
 
 -- Control which packages get to be built
 userPackages :: Packages


### PR DESCRIPTION
-Wall and -fwarn-tabs flags to ghc can now be controlled from Settings/User.hs. This is a first stab at #116.