### PR TITLE
Fix unnecessary import hiding of "parallel"

### DIFF
--- a/src/Base.hs
+++ b/src/Base.hs
@@ -34,7 +34,7 @@ import Data.Function
 import Data.List
 import Data.Maybe
 import Data.Monoid
-import Development.Shake hiding (unit, (*>), parallel)
+import Development.Shake hiding (unit, (*>))
 import Development.Shake.Classes
 import Development.Shake.FilePath
 import System.Console.ANSI


### PR DESCRIPTION
This has been issuing "unnecessary import" warnings for quite some time for me.