### PR TITLE
Add tests

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -30,4 +30,5 @@ install:
 
 build_script:
     - cd C:\msys64\home\ghc\shake-build
+    - echo "" | stack --no-terminal exec -- build.bat selftest
     - echo "" | stack --no-terminal exec -- build.bat -j --no-progress inplace/bin/ghc-stage1.exe

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,7 @@ install:
 
 script:
     - ( cd ghc/shake-build && cabal haddock --internal )
+    - ./ghc/shake-build/build.sh selftest
     - ./ghc/shake-build/build.sh -j --no-progress $TARGET
 
 cache:

--- a/shaking-up-ghc.cabal
+++ b/shaking-up-ghc.cabal
@@ -100,6 +100,7 @@ executable ghc-shake
                        , Settings.Ways
                        , Stage
                        , Target
+                       , Test
                        , Way
 
     default-extensions:  BangPatterns
@@ -111,6 +112,7 @@ executable ghc-shake
                        , FlexibleInstances
                        , OverloadedStrings
                        , RecordWildCards
+                       , ScopedTypeVariables
     build-depends:       base
                        , ansi-terminal >= 0.6
                        , Cabal >= 1.22
@@ -118,6 +120,7 @@ executable ghc-shake
                        , directory >= 1.2
                        , extra >= 1.4
                        , mtl >= 2.2
+                       , QuickCheck >= 2.6
                        , shake >= 0.15
                        , transformers >= 0.4
                        , unordered-containers >= 0.2

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -11,6 +11,7 @@ import qualified Rules.Gmp
 import qualified Rules.Libffi
 import qualified Rules.Oracles
 import qualified Rules.Perl
+import qualified Test
 
 main :: IO ()
 main = shakeArgs options rules
@@ -25,7 +26,8 @@ main = shakeArgs options rules
         , Rules.Gmp.gmpRules
         , Rules.Libffi.libffiRules
         , Rules.Oracles.oracleRules
-        , Rules.packageRules ]
+        , Rules.packageRules
+        , Test.testRules ]
     options = shakeOptions
         { shakeFiles    = Base.shakeFilesPath
         , shakeProgress = progressSimple

--- a/src/Settings/Builders/Ar.hs
+++ b/src/Settings/Builders/Ar.hs
@@ -48,13 +48,5 @@ useSuccessiveInvocations path flagArgs fileArgs = do
 -- | @chunksOfSize size strings@ splits a given list of strings into chunks not
 -- exceeding the given @size@.
 chunksOfSize :: Int -> [String] -> [[String]]
-chunksOfSize _    [] = []
-chunksOfSize size strings = reverse chunk : chunksOfSize size rest
-  where
-    (chunk, rest) = go [] 0 strings
-    go res _         []     = (res, [])
-    go res chunkSize (s:ss) =
-        if newSize > size then (res, s:ss) else go (s:res) newSize ss
-      where
-        newSize = chunkSize + length s
-
+chunksOfSize n = repeatedly f
+    where f xs = splitAt (max 1 $ length $ takeWhile (<= n) $ scanl1 (+) $ map length xs) xs

--- a/src/Settings/Builders/Ar.hs
+++ b/src/Settings/Builders/Ar.hs
@@ -1,4 +1,4 @@
-module Settings.Builders.Ar (arBuilderArgs, arCmd) where
+module Settings.Builders.Ar (arBuilderArgs, arCmd, chunksOfSize) where
 
 import Base
 import Expression

--- a/src/Settings/Builders/Ar.hs
+++ b/src/Settings/Builders/Ar.hs
@@ -46,7 +46,7 @@ useSuccessiveInvocations path flagArgs fileArgs = do
         unit . cmd [path] $ flagArgs ++ argsChunk
 
 -- | @chunksOfSize size strings@ splits a given list of strings into chunks not
--- exceeding the given @size@.
+-- exceeding the given @size@. If that is impossible, it uses singleton chunks.
 chunksOfSize :: Int -> [String] -> [[String]]
 chunksOfSize n = repeatedly f
     where f xs = splitAt (max 1 $ length $ takeWhile (<= n) $ scanl1 (+) $ map length xs) xs

--- a/src/Test.hs
+++ b/src/Test.hs
@@ -1,0 +1,19 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Test (testRules) where
+
+import Way
+import Development.Shake
+import Test.QuickCheck
+
+instance Arbitrary Way where
+    arbitrary = wayFromUnits <$> arbitrary
+
+instance Arbitrary WayUnit where
+    arbitrary = arbitraryBoundedEnum
+
+testRules :: Rules ()
+testRules =
+    phony "selftest" $ do
+        liftIO $ quickCheck $ \(x :: Way) -> read (show x) == x

--- a/src/Test.hs
+++ b/src/Test.hs
@@ -16,4 +16,8 @@ instance Arbitrary WayUnit where
 testRules :: Rules ()
 testRules =
     phony "selftest" $ do
-        liftIO $ quickCheck $ \(x :: Way) -> read (show x) == x
+        test $ \(x :: Way) -> read (show x) == x
+
+
+test :: Testable a => a -> Action ()
+test = liftIO . quickCheck

--- a/src/Test.hs
+++ b/src/Test.hs
@@ -6,6 +6,7 @@ module Test (testRules) where
 import Way
 import Development.Shake
 import Test.QuickCheck
+import Settings.Builders.Ar(chunksOfSize)
 
 instance Arbitrary Way where
     arbitrary = wayFromUnits <$> arbitrary
@@ -17,6 +18,10 @@ testRules :: Rules ()
 testRules =
     phony "selftest" $ do
         test $ \(x :: Way) -> read (show x) == x
+        test $ \n xs ->
+            let res = chunksOfSize n xs
+            in concat res == xs && all (\r -> length r == 1 || length (concat r) <= n) res
+        test $ chunksOfSize 3 ["a","b","c","defg","hi","jk"] == [["a","b","c"],["defg"],["hi"],["jk"]]
 
 
 test :: Testable a => a -> Action ()

--- a/src/Way.hs
+++ b/src/Way.hs
@@ -1,5 +1,5 @@
 module Way (
-    WayUnit (..), Way, wayUnit,
+    WayUnit (..), Way, wayUnit, wayFromUnits,
 
     vanilla, profiling, logging, parallel, granSim,
     threaded, threadedProfiling, threadedLogging,


### PR DESCRIPTION
Only real decision was whether to put the Arbitrary instances in the same module or in a separate module, with orphan instances. Generally orphans should be avoided, but here we're writing an exe and the testing stuff is very much incidental, so I used orphans to keep the main system simple and permit avoiding QuickCheck if we need to.

I added tests for chunksOfSize, and they promptly failed taking up all memory and looping forever. So I rewrote chunksOfSize and now it works and passes all the tests.