### PR TITLE
Report success on IRC only if the build was fixed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ cache:
 
 notifications:
     irc:
-        on_success: always # always/never/change
+        on_success: change # always/never/change
         on_failure: always
         channels:
             - "chat.freenode.net#shaking-up-ghc"


### PR DESCRIPTION
We've reached a somewhat stable level of green-ness on Travis, so I think we can reduce the number of messages to the more relevant ones.