### PR TITLE
Cleanups in libffi

### DIFF
--- a/src/Rules/Actions.hs
+++ b/src/Rules/Actions.hs
@@ -77,7 +77,7 @@ createDirectory dir = do
 removeDirectory :: FilePath -> Action ()
 removeDirectory dir = do
     putBuild $ "| Remove directory " ++ dir
-    liftIO $ IO.removeDirectoryRecursive dir
+    removeDirectoryIfExists dir
 
 -- Note, the source directory is untracked
 moveDirectory :: FilePath -> FilePath -> Action ()

--- a/src/Rules/Actions.hs
+++ b/src/Rules/Actions.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE RecordWildCards #-}
 module Rules.Actions (
-    build, buildWithResources, copyFile, createDirectory, moveDirectory,
+    build, buildWithResources, copyFile, createDirectory, removeDirectory, moveDirectory,
     fixFile, runConfigure, runMake, runBuilder, makeExecutable
     ) where
 
@@ -73,6 +73,11 @@ createDirectory :: FilePath -> Action ()
 createDirectory dir = do
     putBuild $ "| Create directory " ++ dir
     liftIO $ IO.createDirectoryIfMissing True dir
+
+removeDirectory :: FilePath -> Action ()
+removeDirectory dir = do
+    putBuild $ "| Remove directory " ++ dir
+    liftIO $ IO.removeDirectoryRecursive dir
 
 -- Note, the source directory is untracked
 moveDirectory :: FilePath -> FilePath -> Action ()

--- a/src/Rules/Libffi.hs
+++ b/src/Rules/Libffi.hs
@@ -71,7 +71,7 @@ libffiRules :: Rules ()
 libffiRules = do
     libffiDependencies &%> \_ -> do
         when trackBuildSystem $ need [sourcePath -/- "Rules/Libffi.hs"]
-        liftIO $ removeFiles libffiBuild ["//*"]
+        removeDirectory libffiBuild
         createDirectory $ buildRootPath -/- stageString Stage0
 
         tarballs <- getDirectoryFiles "" ["libffi-tarballs/libffi*.tar.gz"]

--- a/src/Rules/Libffi.hs
+++ b/src/Rules/Libffi.hs
@@ -82,6 +82,7 @@ libffiRules = do
         need tarballs
         let libname = dropExtension . dropExtension . takeFileName $ head tarballs
 
+        removeDirectory (buildRootPath -/- libname)
         actionFinally (do
             build $ fullTarget libffiTarget Tar tarballs [buildRootPath]
             moveDirectory (buildRootPath -/- libname) libffiBuild) $

--- a/src/Rules/Libffi.hs
+++ b/src/Rules/Libffi.hs
@@ -82,9 +82,10 @@ libffiRules = do
         need tarballs
         let libname = dropExtension . dropExtension . takeFileName $ head tarballs
 
-        build $ fullTarget libffiTarget Tar tarballs [buildRootPath]
-        actionFinally (moveDirectory (buildRootPath -/- libname) libffiBuild) $
-            removeFiles buildRootPath [libname <//> "*"]
+        actionFinally (do
+            build $ fullTarget libffiTarget Tar tarballs [buildRootPath]
+            moveDirectory (buildRootPath -/- libname) libffiBuild) $
+                removeFiles buildRootPath [libname <//> "*"]
 
         fixFile (libffiBuild -/- "Makefile.in") fixLibffiMakefile
 

--- a/src/Rules/Libffi.hs
+++ b/src/Rules/Libffi.hs
@@ -28,11 +28,11 @@ libffiLibrary :: FilePath
 libffiLibrary = libffiBuild -/- "inst/lib/libffi.a"
 
 fixLibffiMakefile :: String -> String
-fixLibffiMakefile = unlines . map
-    ( replace "-MD" "-MMD"
+fixLibffiMakefile =
+      replace "-MD" "-MMD"
     . replace "@toolexeclibdir@" "$(libdir)"
     . replace "@INSTALL@" "$(subst ../install-sh,C:/msys/home/chEEtah/ghc/install-sh,@INSTALL@)"
-    ) . lines
+
 
 -- TODO: remove code duplication (see Settings/Builders/GhcCabal.hs)
 configureEnvironment :: Action [CmdOption]


### PR DESCRIPTION
Following on from #156, I think a little more needs to be in the `actionFinally`, so that if things fail while extracting the tarball we still clean up properly.