### PR TITLE
#155, fix the name of the QuickCheck package

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ to adjust anything if you are already familiar with building ghc using the `make
 build system.
 
 Furthermore, we depend on the following packages which need to be installed:
-`ansi-terminal`, `mtl`, `shake`, `quickcheck`.
+`ansi-terminal`, `mtl`, `shake`, `QuickCheck`.
 
 ### Getting the source and configuring GHC
 


### PR DESCRIPTION
It's package name is camel case rather than lowercase (unlike most packages)