### PR TITLE
fix "dirs" to "dir" for gmp and iconv libraries

### DIFF
--- a/cfg/system.config.in
+++ b/cfg/system.config.in
@@ -100,11 +100,11 @@ conf-ld-linker-args-stage2  = @CONF_LD_LINKER_OPTS_STAGE2@
 # Include and library directories:
 #=================================
 
-iconv-include-dirs = @ICONV_INCLUDE_DIRS@
-iconv-lib-dirs     = @ICONV_LIB_DIRS@
+iconv-include-dir = @ICONV_INCLUDE_DIRS@
+iconv-lib-dir     = @ICONV_LIB_DIRS@
 
-gmp-include-dirs   = @GMP_INCLUDE_DIRS@
-gmp-lib-dirs       = @GMP_LIB_DIRS@
+gmp-include-dir   = @GMP_INCLUDE_DIRS@
+gmp-lib-dir       = @GMP_LIB_DIRS@
 
 use-system-ffi     = @UseSystemLibFFI@
 ffi-include-dir   = @FFIIncludeDir@

--- a/src/Oracles/Config/Setting.hs
+++ b/src/Oracles/Config/Setting.hs
@@ -49,16 +49,16 @@ data Setting = BuildArch
              | TargetVendor
              | FfiIncludeDir
              | FfiLibDir
+             | GmpIncludeDir
+             | GmpLibDir
+             | IconvIncludeDir
+             | IconvLibDir
 
 data SettingList = ConfCcArgs Stage
                  | ConfCppArgs Stage
                  | ConfGccLinkerArgs Stage
                  | ConfLdLinkerArgs Stage
-                 | GmpIncludeDirs
-                 | GmpLibDirs
                  | HsCppArgs
-                 | IconvIncludeDirs
-                 | IconvLibDirs
 
 setting :: Setting -> Action String
 setting key = askConfig $ case key of
@@ -92,6 +92,10 @@ setting key = askConfig $ case key of
     TargetVendor       -> "target-vendor"
     FfiIncludeDir      -> "ffi-include-dir"
     FfiLibDir          -> "ffi-lib-dir"
+    GmpIncludeDir      -> "gmp-include-dir"
+    GmpLibDir          -> "gmp-lib-dir"
+    IconvIncludeDir    -> "iconv-include-dir"
+    IconvLibDir        -> "iconv-lib-dir"
 
 settingList :: SettingList -> Action [String]
 settingList key = fmap words $ askConfig $ case key of
@@ -99,11 +103,7 @@ settingList key = fmap words $ askConfig $ case key of
     ConfCppArgs       stage -> "conf-cpp-args-"        ++ stageString stage
     ConfGccLinkerArgs stage -> "conf-gcc-linker-args-" ++ stageString stage
     ConfLdLinkerArgs  stage -> "conf-ld-linker-args-"  ++ stageString stage
-    GmpIncludeDirs          -> "gmp-include-dirs"
-    GmpLibDirs              -> "gmp-lib-dirs"
     HsCppArgs               -> "hs-cpp-args"
-    IconvIncludeDirs        -> "iconv-include-dirs"
-    IconvLibDirs            -> "iconv-lib-dirs"
 
 getSetting :: Setting -> ReaderT a Action String
 getSetting = lift . setting

--- a/src/Rules/Gmp.hs
+++ b/src/Rules/Gmp.hs
@@ -62,10 +62,10 @@ configureArguments = do
 
 configureIntGmpArguments :: Action [String]
 configureIntGmpArguments = do
-    includes      <- settingList GmpIncludeDirs
-    libs          <- settingList GmpLibDirs
-    return $ map ("--with-gmp-includes=" ++) includes
-          ++ map ("--with-gmp-libraries=" ++) libs
+    includes      <- setting GmpIncludeDir
+    libs          <- setting GmpLibDir
+    return $ map ("--with-gmp-includes=" ++) [includes]
+          ++ map ("--with-gmp-libraries=" ++) [libs]
 
 -- TODO: we rebuild gmp every time.
 gmpRules :: Rules ()

--- a/src/Settings/Builders/GhcCabal.hs
+++ b/src/Settings/Builders/GhcCabal.hs
@@ -79,10 +79,10 @@ configureArgs = do
         , conf "LDFLAGS"  ldFlags
         , conf "CPPFLAGS" cppFlags
         , appendSubD "--gcc-options" $ cFlags <> ldFlags
-        , conf "--with-iconv-includes"    $ argSettingList IconvIncludeDirs
-        , conf "--with-iconv-libraries"   $ argSettingList IconvLibDirs
-        , conf "--with-gmp-includes"      $ argSettingList GmpIncludeDirs
-        , conf "--with-gmp-libraries"     $ argSettingList GmpLibDirs
+        , conf "--with-iconv-includes"    $ argSetting IconvIncludeDir
+        , conf "--with-iconv-libraries"   $ argSetting IconvLibDir
+        , conf "--with-gmp-includes"      $ argSetting GmpIncludeDir
+        , conf "--with-gmp-libraries"     $ argSetting GmpLibDir
         , crossCompiling ? (conf "--host" $ argSetting TargetPlatformFull)
         , conf "--with-cc" $ argStagedBuilderPath Gcc ]
 

--- a/src/Settings/Builders/Hsc2Hs.hs
+++ b/src/Settings/Builders/Hsc2Hs.hs
@@ -17,7 +17,7 @@ hsc2hsBuilderArgs :: Args
 hsc2hsBuilderArgs = builder Hsc2Hs ? do
     stage   <- getStage
     ccPath  <- lift . builderPath $ Gcc stage
-    gmpDirs <- getSettingList GmpIncludeDirs
+    gmpDir  <- getSetting GmpIncludeDir
     cFlags  <- getCFlags
     lFlags  <- getLFlags
     top     <- getTopDirectory
@@ -32,7 +32,7 @@ hsc2hsBuilderArgs = builder Hsc2Hs ? do
     mconcat [ arg $ "--cc=" ++ ccPath
             , arg $ "--ld=" ++ ccPath
             , notM windowsHost ? arg "--cross-safe"
-            , append $ map ("-I"       ++) gmpDirs
+            , append $ map ("-I"       ++) [gmpDir]
             , append $ map ("--cflag=" ++) cFlags
             , append $ map ("--lflag=" ++) lFlags
             , notStage0 ? crossCompiling ? arg "--cross-compile"


### PR DESCRIPTION
@snowleopard this is requested dirs to dir pull request. I'm trying to make it as simple as possible and so putting dir into list whenever applicable to keep code intact. Tested on Solaris 11 with system supplied gmp and ffi libraries.