### PR TITLE
do not pass --with-intree-gmp to configure when system gmp is used

### DIFF
--- a/src/Settings/Packages/IntegerGmp.hs
+++ b/src/Settings/Packages/IntegerGmp.hs
@@ -4,7 +4,6 @@ import Base
 import Expression
 import GHC (integerGmp)
 import Predicates (builder, builderGcc, package)
-import Settings.Builders.Common
 import Settings.Paths
 import Oracles.Config.Setting
 

--- a/src/Settings/Packages/IntegerGmp.hs
+++ b/src/Settings/Packages/IntegerGmp.hs
@@ -15,17 +15,13 @@ import Oracles.Config.Setting
 integerGmpPackageArgs :: Args
 integerGmpPackageArgs = package integerGmp ? do
     let includeGmp = "-I" ++ gmpBuildPath -/- "include"
-    gmp_includedir <- getSetting GmpIncludeDir
-    gmp_libdir <- getSetting GmpLibDir
-    let gmp_args = if (gmp_includedir == "" && gmp_libdir == "")
-                   then
-                   [ arg "--configure-option=--with-intree-gmp" ]
-                   else
-                   []
+    gmpIncludeDir <- getSetting GmpIncludeDir
+    gmpLibDir <- getSetting GmpLibDir
 
     mconcat [ builder GhcCabal ? mconcat
-              (gmp_args ++
-               [ appendSub "--configure-option=CFLAGS" [includeGmp]
-               , appendSub "--gcc-options"             [includeGmp] ] )
+              [ (null gmpIncludeDir && null gmpLibDir) ?
+                arg "--configure-option=--with-intree-gmp"
+              , appendSub "--configure-option=CFLAGS" [includeGmp]
+              , appendSub "--gcc-options"             [includeGmp] ]
 
             , builderGcc ? arg includeGmp ]

--- a/src/Settings/Packages/IntegerGmp.hs
+++ b/src/Settings/Packages/IntegerGmp.hs
@@ -4,7 +4,9 @@ import Base
 import Expression
 import GHC (integerGmp)
 import Predicates (builder, builderGcc, package)
+import Settings.Builders.Common
 import Settings.Paths
+import Oracles.Config.Setting
 
 -- TODO: move build artefacts to buildRootPath, see #113
 -- TODO: Is this needed?
@@ -14,11 +16,17 @@ import Settings.Paths
 integerGmpPackageArgs :: Args
 integerGmpPackageArgs = package integerGmp ? do
     let includeGmp = "-I" ++ gmpBuildPath -/- "include"
+    gmp_includedir <- getSetting GmpIncludeDir
+    gmp_libdir <- getSetting GmpLibDir
+    let gmp_args = if (gmp_includedir == "" && gmp_libdir == "")
+                   then
+                   [ arg "--configure-option=--with-intree-gmp" ]
+                   else
+                   []
+
     mconcat [ builder GhcCabal ? mconcat
-              [ arg "--configure-option=--with-intree-gmp"
-              , appendSub "--configure-option=CFLAGS" [includeGmp]
-              , appendSub "--gcc-options"             [includeGmp] ]
+              (gmp_args ++
+               [ appendSub "--configure-option=CFLAGS" [includeGmp]
+               , appendSub "--gcc-options"             [includeGmp] ] )
 
             , builderGcc ? arg includeGmp ]
-  where
-


### PR DESCRIPTION
@snowleopard this PR fixes issue of ghc-cabal configuring integer-gmp with intree gmp even when user prefers to use system supplied gmp.