### PR TITLE
Allow building ghc-shake with stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ cfg/system.config
 cabal.sandbox.config
 dist/
 .cabal-sandbox/
+.stack-work/

--- a/build.cabal.sh
+++ b/build.cabal.sh
@@ -28,8 +28,8 @@ function rl {
     echo "$RESULT"
 }
 
-absoltueRoot="$(dirname "$(rl "$0")")"
-cd "$absoltueRoot"
+absoluteRoot="$(dirname "$(rl "$0")")"
+cd "$absoluteRoot"
 
 # Initialize sandbox if necessary
 if ! ( cabal sandbox hc-pkg list 2>&1 > /dev/null ); then
@@ -42,6 +42,6 @@ fi
 
 cabal run ghc-shake --             \
     --lint                         \
-    --directory "$absoltueRoot/.." \
+    --directory "$absoluteRoot/.." \
     --colour                       \
     "$@"

--- a/build.stack.sh
+++ b/build.stack.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# readlink on os x, doesn't support -f, to prevent the
+# need of installing coreutils (e.g. through brew, just
+# for readlink, we use the follownig substitute.
+#
+# source: http://stackoverflow.com/a/1116890
+function rl {
+    TARGET_FILE="$1"
+
+    cd "$(dirname "$TARGET_FILE")"
+    TARGET_FILE="$(basename "$TARGET_FILE")"
+
+    # Iterate down a (possible) chain of symlinks
+    while [ -L "$TARGET_FILE" ]
+    do
+        TARGET_FILE="$(readlink "$TARGET_FILE")"
+        cd "$(dirname "$TARGET_FILE")"
+        TARGET_FILE="$(basename "$TARGET_FILE")"
+    done
+
+    # Compute the canonicalized name by finding the physical path
+    # for the directory we're in and appending the target file.
+    PHYS_DIR="$(pwd -P)"
+    RESULT="$PHYS_DIR/$TARGET_FILE"
+    echo "$RESULT"
+}
+
+absoltueRoot="$(dirname "$(rl "$0")")"
+cd "$absoltueRoot"
+
+stack build --no-library-profiling
+
+stack exec ghc-shake --            \
+    --lint                         \
+    --directory "$absoltueRoot/.." \
+    --colour                       \
+    "$@"

--- a/build.stack.sh
+++ b/build.stack.sh
@@ -28,13 +28,13 @@ function rl {
     echo "$RESULT"
 }
 
-absoltueRoot="$(dirname "$(rl "$0")")"
-cd "$absoltueRoot"
+absoluteRoot="$(dirname "$(rl "$0")")"
+cd "$absoluteRoot"
 
 stack build --no-library-profiling
 
 stack exec ghc-shake --            \
     --lint                         \
-    --directory "$absoltueRoot/.." \
+    --directory "$absoluteRoot/.." \
     --colour                       \
     "$@"

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,35 @@
+# For more information, see: http://docs.haskellstack.org/en/stable/yaml_configuration.html
+
+# Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
+resolver: lts-4.2
+
+# Local packages, usually specified by relative directory name
+packages:
+- '.'
+
+# Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
+extra-deps: []
+
+# Override default flag values for local packages and extra-deps
+flags: {}
+
+# Extra package databases containing global packages
+extra-package-dbs: []
+
+# Control whether we use the GHC we find on the path
+# system-ghc: false
+
+# Require a specific version of stack, using version ranges
+# require-stack-version: -any # Default
+# require-stack-version: >= 1.0.0
+
+# Override the architecture used by stack, especially useful on Windows
+# arch: i386
+# arch: x86_64
+
+# Extra directories used by stack for building
+# extra-include-dirs: [/path/to/dir]
+# extra-lib-dirs: [/path/to/dir]
+
+# Allow a newer minor version of GHC than the snapshot specifies
+# compiler-check: newer-minor


### PR DESCRIPTION
I've found stack to be more reliable than cabal sandboxes.

This PR adds `build.stack.sh` based on `build.cabal.sh`