### PR TITLE
Update stack.yaml to lts-5.1

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
 # For more information, see: http://docs.haskellstack.org/en/stable/yaml_configuration.html
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-4.2
+resolver: lts-5.1
 
 # Local packages, usually specified by relative directory name
 packages:


### PR DESCRIPTION
I don't plan to change this file every time there is a new stackage lts, but lts-4.x has a bug with aeson.