### PR TITLE
Ensure that if ghc compilation fails then we return a non-zero error code from build.bat

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -21,8 +21,8 @@
 
 @ghc %ghcArgs%
 
-@if %ERRORLEVEL% EQU 0 (
-    @rem Unset GHC_PACKAGE_PATH variable, as otherwise ghc-cabal complains
-    @set GHC_PACKAGE_PATH=
-    @.shake\build %shakeArgs%
-)
+@if %ERRORLEVEL% NEQ 0 EXIT /B %ERRORLEVEL%
+
+@rem Unset GHC_PACKAGE_PATH variable, as otherwise ghc-cabal complains
+@set GHC_PACKAGE_PATH=
+@.shake\build %shakeArgs%


### PR DESCRIPTION
At the moment if compiling the build script fails the build.bat returns 0, it should return 1 to indicate failure. I checked it still returns 0 on success and 1 on compilation failure.