### PR TITLE
Add shake-0.15.6 to stack extra-deps

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -8,7 +8,8 @@ packages:
 - '.'
 
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
-extra-deps: []
+extra-deps:
+- shake-0.15.6
 
 # Override default flag values for local packages and extra-deps
 flags: {}


### PR DESCRIPTION
Since you bumped the lower bound, this is necessary for `stack build` to work.