### PR TITLE
fix management of nontrivial dynamic flavours of libHSrts

### DIFF
--- a/src/Oracles/Setting.hs
+++ b/src/Oracles/Setting.hs
@@ -186,4 +186,4 @@ libsuf way =
     extension <- setting DynamicExtension  -- e.g., .dll or .so
     version   <- setting ProjectVersion    -- e.g., 7.11.20141222
     let suffix = waySuffix $ removeWayUnit Dynamic way
-    return $ "-ghc" ++ version ++ suffix ++ extension
+    return $ suffix ++ "-ghc" ++ version ++ extension

--- a/src/Rules/Library.hs
+++ b/src/Rules/Library.hs
@@ -134,7 +134,7 @@ data LibA = LibA String [Integer] Way deriving (Eq, Show)
 -- | > <so or dylib>
 data DynLibExt = So | Dylib deriving (Eq, Show)
 
--- | > libHS<pkg name>-<pkg version>-ghc<ghc version>[_<way suffix>].<so or dylib>
+-- | > libHS<pkg name>-<pkg version>[_<way suffix>]-ghc<ghc version>.<so or dylib>
 data LibDyn = LibDyn String [Integer] Way DynLibExt deriving (Eq, Show)
 
 -- | > HS<pkg name>-<pkg version>[_<way suffix>].o
@@ -231,8 +231,8 @@ parseLibDynFilename :: String -> Parsec.Parsec String () LibDyn
 parseLibDynFilename ext = do
     _ <- Parsec.string "libHS"
     (pkgname, pkgver) <- parsePkgId
-    _ <- optional $ Parsec.string "-ghc" *> parsePkgVersion
     way <- addWayUnit Dynamic <$> parseWaySuffix dynamic
+    _ <- optional $ Parsec.string "-ghc" *> parsePkgVersion
     _ <- Parsec.string ("." ++ ext)
     return (LibDyn pkgname pkgver way $ if ext == "so" then So else Dylib)
 

--- a/src/Settings/Packages.hs
+++ b/src/Settings/Packages.hs
@@ -285,6 +285,7 @@ rtsPackageArgs = package rts ? do
           [ any (wayUnit Profiling) rtsWays ? arg "profiling"
           , any (wayUnit Debug) rtsWays ? arg "debug"
           , any (wayUnit Logging) rtsWays ? arg "logging"
+          , any (wayUnit Dynamic) rtsWays ? arg "dynamic"
           ]
         , builder (Cc FindCDependencies) ? cArgs
         , builder (Ghc CompileCWithGhc) ? map ("-optc" ++) <$> cArgs


### PR DESCRIPTION
Where non trivial means e.g "threaded dynamic", i.e not just "dynamic".

This requires a Cabal patch: https://github.com/haskell/cabal/pull/5606
and a GHC patch that bumps Cabal and also adds:

``` patch
diff --git a/rts/rts.cabal.in b/rts/rts.cabal.in
index 76fd353134..9c95fbb342 100644
--- a/rts/rts.cabal.in
+++ b/rts/rts.cabal.in
@@ -39,6 +39,8 @@ flag debug
   default: False
 flag logging
   default: False
+flag dynamic
+  default: False
 
 library
     -- rts is a wired in package and
@@ -65,8 +67,14 @@ library
         extra-library-flavours: _debug_p _thr_debug_p
     if flag(debug)
       extra-library-flavours: _debug _thr_debug
+      if flag(dynamic)
+        extra-dynamic-library-flavours: _debug _thr_debug
     if flag(logging)
       extra-library-flavours: _l _thr_l
+      if flag(dynamic)
+        extra-dynamic-library-flavours: _l _thr_l
+    if flag(dynamic)
+      extra-dynamic-library-flavours: _thr
 
     exposed: True
     exposed-modules:
```

I will submit it once the Cabal patch is merged. Until then, I thought it would be a good idea to have this PR ready. As reported in #695 I can build & install all the dynamic RTS flavours I want with all those patches. This effectively fixes #695.